### PR TITLE
メニュー画面でスキルを使用するとエラーになる不具合を修正

### DIFF
--- a/InspirationSkill/InspirationSkill.js
+++ b/InspirationSkill/InspirationSkill.js
@@ -402,7 +402,7 @@
 
   const _Game_BattlerBase_PaySkillCost = Game_BattlerBase.prototype.paySkillCost
   Game_BattlerBase.prototype.paySkillCost = function(skill) {
-    if (!this.currentAction()._inspirationFlag) {
+    if (!this.currentAction()?._inspirationFlag) {
       _Game_BattlerBase_PaySkillCost.apply(this, arguments);
     }
   };

--- a/InspirationSkill/InspirationSkill.js
+++ b/InspirationSkill/InspirationSkill.js
@@ -198,6 +198,7 @@
  */
 
 (() => {
+  'use strict';
 
   const pluginName = "InspirationSkill";
 
@@ -211,7 +212,7 @@
   PluginManager_Parser.prototype.parse = function (params) {
      if (this.isObject(params, "string")) {
         try {
-           parseParams = JSON.parse(params)
+           const parseParams = JSON.parse(params)
            params = this.parse(parseParams);
         } catch (e) {
            params = this.convertNumber(params);
@@ -339,7 +340,7 @@
       }
 
       if (inspirationSkills.length) {
-        inspirationSkill = inspirationSkills[Math.floor( Math.random() * inspirationSkills.length )];
+        const inspirationSkill = inspirationSkills[Math.floor( Math.random() * inspirationSkills.length )];
         subject.currentAction()._item._itemId = inspirationSkill;
         subject.currentAction()._inspirationFlag = true;
         subject.learnSkill(inspirationSkill);


### PR DESCRIPTION
メニュー画面では `Game_Battler.prototype.currentAction` から `Game_Action` インスタンスではなく `undefined` が返るため、メニュー画面で回復スキルなどを使用した際にエラーになります。

これを修正するPRになります。