### PR TITLE
createTextManagerに関する競合の修正

### DIFF
--- a/SkillPoint/SkillPoint.js
+++ b/SkillPoint/SkillPoint.js
@@ -483,13 +483,27 @@ $skillPoint = null;
   const _Scene_Boot_OnDatabaseLoaded = Scene_Boot.prototype.onDatabaseLoaded;
   Scene_Boot.prototype.onDatabaseLoaded = function() {
     _Scene_Boot_OnDatabaseLoaded.apply(this, arguments);
-    this.createTextManager();
+    /**
+     * MaterialShop.js でも呼び出される可能性がある
+     * 既に呼び出していた場合は何もしない
+     */
+    if (!TextManager.sp) {
+      this.createTextManager();
+    }
   };
 
   //-----------------------------------------------------------------------------
   // TextManagerオブジェクトにスキルポイント用のプロパティを追加
   //-----------------------------------------------------------------------------
+  const _Scene_Boot_createTextManager = Scene_Boot.prototype.createTextManager;
   Scene_Boot.prototype.createTextManager = function() {
+    /**
+     * MaterialShop.js よりも後に読み込まれた場合、
+     * 単純に上書きすると向こうの処理を潰してしまう
+     */
+    if (_Scene_Boot_createTextManager) {
+      _Scene_Boot_createTextManager.call(this);
+    }
      Object.defineProperties(TextManager, {
         sp: TextManager.getter("skillPoint", 0),
         spA: TextManager.getter("skillPoint", 1),

--- a/request/MaterialShop/MaterialShop.js
+++ b/request/MaterialShop/MaterialShop.js
@@ -638,11 +638,33 @@ $teleport = null;
     Scene_Shop.prototype.commandSell.call(this);
   };
 
+  //-----------------------------------------------------------------------------
+  // Scene_Boot.prototype.onDatabaseLoaded関数の再定義
+  //-----------------------------------------------------------------------------
+  const _Scene_Boot_OnDatabaseLoaded = Scene_Boot.prototype.onDatabaseLoaded;
+  Scene_Boot.prototype.onDatabaseLoaded = function() {
+    _Scene_Boot_OnDatabaseLoaded.apply(this, arguments);
+    /**
+     * SkillPoint.js でも呼び出される可能性がある
+     * 既に呼び出していた場合は何もしない
+     */
+    if (!TextManager.quantity) {
+      this.createTextManager();
+    }
+  };
 
   //-----------------------------------------------------------------------------
-  // TextManagerオブジェクトにス素材ショップ用のプロパティを追加
+  // TextManagerオブジェクトに素材ショップ用のプロパティを追加
   //-----------------------------------------------------------------------------
+  const _Scene_Boot_createTextManager = Scene_Boot.prototype.createTextManager;
   Scene_Boot.prototype.createTextManager = function() {
+    /**
+     * SkillPoint.js より後に読み込まれた場合、
+     * 単純に上書きすると向こうの処理を潰してしまう
+     */
+    if (_Scene_Boot_createTextManager) {
+      _Scene_Boot_createTextManager.call(this);
+    }
      Object.defineProperties(TextManager, {
         quantity: TextManager.getter("material", "quantity"),
         materialMsg: TextManager.getter("material", "materialMsg")


### PR DESCRIPTION
[ツクマテ](https://tm.lucky-duet.com/viewtopic.php?f=116&t=12247) より。
MaterialShop.js が、 SkillPoint.js を必要としており、それより後に読み込まないと動かない（個数の単位が `undefined` となり、カーソルを合わせるとエラーで停止する）状態になっていました。

また、 SkillPoint.js は `createTextManager` メソッドを潰されるため、 MaterialShop.js を後に読み込むと動きません。

これらを修正します。